### PR TITLE
Fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 script:
   - set -e
-  - docker build -t ${GROUP}/${REPO}:${COMMIT} 
+  - docker build -t ${GROUP}/${REPO}:${COMMIT} .
 
 after_success:
   - set -e;


### PR DESCRIPTION
The Docker build command was missing a dot. Fixed